### PR TITLE
Fix log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/api.js
+++ b/api.js
@@ -2,6 +2,7 @@ var request = require('request');
 var errors = require('./errors');
 var _ = require('underscore');
 var url = require('url');
+var util = require('util');
 
 
 var DEFAULT_ERROR = 'There was a problem accessing this data.';
@@ -113,8 +114,8 @@ function remote (method, path, options, callback) {
   var endpointUrl = getFullUrl(this.origin, path);
   request[method](endpointUrl, options, function(err, response, body) {
 
-    console.log('info', 'API request: "%s %s" %s',
-      method.toUpperCase(), endpointUrl, response ? response.statusCode : "Error", err);
+    console.log(util.format('API request: "%s %s" %s',
+      method.toUpperCase(), endpointUrl, response ? response.statusCode : "Error", err));
 
     if (err)
       return callback(new errors.Unknown(err));


### PR DESCRIPTION
I think a bunyan logging statement was converted to `console.log`, and ended up looking like this:

```
info API request: "%s %s" %s GET http://localhost:3001/badges 200 null
```

when it should be

```
API request: "GET http://localhost:3001/badges" 200
```

I think this will fix it.
